### PR TITLE
Fix Power Cloud endpoint for multi-zone regions

### DIFF
--- a/lib/ibm/cloud/sdk/power_iaas.rb
+++ b/lib/ibm/cloud/sdk/power_iaas.rb
@@ -18,7 +18,7 @@ module IBM
         end
 
         def endpoint
-          "https://#{region}.power-iaas.cloud.ibm.com/pcloud/v1"
+          "https://#{region.sub(/-\d$/, '')}.power-iaas.cloud.ibm.com/pcloud/v1"
         end
 
         # Get all PVM instances in an IBM Power Cloud instance


### PR DESCRIPTION
The 'region' value contains a zone enumeration in regions with more than
one zone (e.g. 'eu-de-1'). A single API endpoint is provided for each
region regardless of zone count (e.g.
'https://eu-de.power-iaas.cloud.ibm.com').