### PR TITLE
Add PowerIaas 'delete_volume' method

### DIFF
--- a/lib/ibm/cloud/sdk/power_iaas.rb
+++ b/lib/ibm/cloud/sdk/power_iaas.rb
@@ -113,6 +113,13 @@ module IBM
           get("cloud-instances/#{guid}/volumes/#{volume_id}")
         end
 
+        # Delete a volume
+        #
+        # @param volume_id [String] The ID of a volume
+        def delete_volume(volume_id)
+          delete("cloud-instances/#{guid}/volumes/#{volume_id}")
+        end
+
         # Get all networks in an IBM Power Cloud instance
         #
         # @return [Array<Hash>] all networks for this IBM Power Cloud instance


### PR DESCRIPTION
Add 'delete_volume' method to facilitate deletion of Power Cloud
volumes.

API doc reference:
https://cloud.ibm.com/apidocs/power-cloud#pcloud-cloudinstances-volumes-delete