### PR TITLE
Resource controller retrieve by ID

### DIFF
--- a/lib/ibm/cloud/sdk/resource_controller.rb
+++ b/lib/ibm/cloud/sdk/resource_controller.rb
@@ -11,12 +11,6 @@ module IBM
           @token = token
         end
 
-        def get_resources
-          resources = get("resource_instances")["resources"] || []
-
-          resources.map { |instance| Resource.new(instance) }
-        end
-
         def get_resource(guid)
           Resource.new(get("resource_instances/#{guid}"))
         end

--- a/lib/ibm/cloud/sdk/resource_controller.rb
+++ b/lib/ibm/cloud/sdk/resource_controller.rb
@@ -2,6 +2,7 @@ module IBM
   module Cloud
     module SDK
       class ResourceController < BaseService
+        require "ibm/cloud/sdk/resource_controller/resource"
         def endpoint
           "https://resource-controller.cloud.ibm.com/v2"
         end
@@ -13,12 +14,11 @@ module IBM
         def get_resources
           resources = get("resource_instances")["resources"] || []
 
-          require "ibm/cloud/sdk/resource_controller/resource"
           resources.map { |instance| Resource.new(instance) }
         end
 
         def get_resource(guid)
-          get_resources.detect { |resource| resource.guid == guid }
+          Resource.new(get("resource_instances/#{guid}"))
         end
 
         private


### PR DESCRIPTION
Speaking of #10, the resource controller 'get_resource' method was retrieving the list of all resources without any type of pagination. Turns out there is an API call to get resources directly by ID (which corresponds to the Power Cloud GUID) which makes for an easy immediate fix.

I believe @blancett was failing PowerVS registration with his account due to this bug.

In the future if we want to register via instance name string we would need to add the 'get_resources' method back with pagination.