### PR TITLE
Create a developer friendly console.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,3 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in ibm-cloud-sdk.gemspec
 gemspec
-
-gem "rake", "~> 12.0"
-gem "rspec", "~> 3.0"

--- a/bin/console
+++ b/bin/console
@@ -15,7 +15,7 @@ begin
     def self.class_option(sym)
       opts = IBM::CloudSDK.env_options[sym]
       default = ENV[opts[:env_var]] || opts[:default]
-      description = "#{opts[:desc]} Environemnt Variable: #{default}"
+      description = "#{opts[:desc]} Environemnt Variable: #{opts[:env_var]}"
       super(sym, { desc: description, default: default })
     end
 

--- a/bin/console
+++ b/bin/console
@@ -28,7 +28,7 @@ begin
     desc 'cli', 'Start a Cloud SDK CLI'
     def cli
       IBM::CloudSDK.cli_help
-      IBM::CloudSDK.new(cli_options: options)
+      IBM::CloudSDK.new(cli_options: options).pry
     rescue RuntimeError, ArgumentError => e
       puts e.full_message
     end
@@ -53,7 +53,7 @@ begin
   end
 
   CloudCLI.default_command(:cli)
-  CloudCLI.start(ARGV).pry
+  CloudCLI.start(ARGV)
 rescue LoadError
   require 'irb'
   IRB.start(__FILE__)

--- a/bin/console
+++ b/bin/console
@@ -1,14 +1,60 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-require "bundler/setup"
-require "ibm/cloud/sdk"
+require 'bundler/setup'
+require 'ibm-cloud-sdk'
 
-# You can add fixtures and/or initialization code here to make experimenting
-# with your gem easier. You can also use a different console, if you like.
+begin
+  require 'pry'
+  require 'thor'
 
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
+  # A Thor CLI for instaiating the CloudSDK.
+  class CloudCLI < Thor
+    include Thor::Actions
 
-require "irb"
-IRB.start(__FILE__)
+    def self.class_option(sym)
+      opts = IBM::CloudSDK.env_options[sym]
+      default = ENV[opts[:env_var]] || opts[:default]
+      description = "#{opts[:desc]} Environemnt Variable: #{default}"
+      super(sym, { desc: description, default: default })
+    end
+
+    class_option :api_key
+    class_option :region
+    class_option :crn
+    class_option :guid
+    class_option :tenant
+
+    desc 'cli', 'Start a Cloud SDK CLI'
+    def cli
+      IBM::CloudSDK.cli_help
+      IBM::CloudSDK.new(cli_options: options)
+    rescue RuntimeError, ArgumentError => e
+      puts e.full_message
+    end
+
+    desc 'variables output ', 'Save the options to a Envionrment variables source file.'
+    def variables(output)
+      script = "# Source this file to set the environment variables necessary for the Cloud SDK.\n"
+      IBM::CloudSDK.env_options.each do |k, v|
+        script += "export #{v[:env_var]}=#{options[k.to_sym]}\n"
+      end
+      script += "\n"
+      create_file(output, script)
+    end
+
+    # Print help for command.
+    # @param command [String] The command to get help for. default: nil
+    # @param subcommand [Boolean] Whether this is a subcommand. default: false
+    # @return [String]
+    def help(command = nil, subcommand = false)
+      super(command, subcommand)
+    end
+  end
+
+  CloudCLI.default_command(:cli)
+  CloudCLI.start(ARGV).pry
+rescue LoadError
+  require 'irb'
+  IRB.start(__FILE__)
+end

--- a/ibm-cloud-sdk.gemspec
+++ b/ibm-cloud-sdk.gemspec
@@ -25,4 +25,10 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rest-client"
   spec.add_dependency "http"
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'pry', '~> 0.13'
+  spec.add_development_dependency 'pry-byebug', '~> 3.9.0'
+  spec.add_development_dependency 'thor', '~> 1.0'
+  spec.add_development_dependency 'rubocop', '~> 0.91.0'
 end

--- a/ibm-cloud-sdk.gemspec
+++ b/ibm-cloud-sdk.gemspec
@@ -27,7 +27,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "http"
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'pry', '~> 0.13'
+  spec.add_development_dependency 'pry', '~> 0.13.1'
+  spec.add_development_dependency 'byebug', '~> 11.1.0'
   spec.add_development_dependency 'pry-byebug', '~> 3.9.0'
   spec.add_development_dependency 'thor', '~> 1.0'
   spec.add_development_dependency 'rubocop', '~> 0.91.0'

--- a/lib/ibm/cloud/sdk/vpc/cloud_sdk.rb
+++ b/lib/ibm/cloud/sdk/vpc/cloud_sdk.rb
@@ -5,29 +5,101 @@ require 'ibm/cloud/sdk/vpc/helpers/connection'
 require 'ibm/cloud/sdk/vpc'
 
 module IBM
-    # Holds the SDK pieces.
-    class CloudSDK
-      def initialize(api_key, logger: nil, options: {})
-        @logger = logger
-        @logger ||= Logger.new($stdout, level: :warn)
+  # Holds the SDK pieces.
+  class CloudSDK
+    # Controls the CLI options help text and environment variables used.
+    def self.env_options
+      {
+        api_key: {
+          type: :string,
+          desc: 'The API Key to log into IBM Cloud',
+          env_var: 'IBM_CLOUD_APIKEY'
+        },
+        region: {
+          type: :string,
+          desc: 'The region to connect to',
+          env_var: 'IBM_CLOUD_REGION',
+          default: 'us-east'
+        },
+        crn: {
+          type: :string,
+          desc: 'The CRN for the region.',
+          env_var: 'IBM_CLOUD_CRN'
+        },
+        guid: {
+          type: :string,
+          desc: 'The GUID for the power env.',
+          env_var: 'IBM_CLOUD_GUID'
+        },
+        tenant: {
+          type: :string,
+          desc: 'The tenant for the region.',
+          env_var: 'IBM_CLOUD_TENANT'
+        }
+      }.freeze
+    end
 
-        @client = HTTP.use(http_options(options))
-        @connection = IBM::Cloud::SDK::VPC::Connection.new(api_key, logger: @logger, client: @client)
+    # Print when called from the CLI. Putting here to ensure changes in class are reflected in message.
+    def self.cli_help
+      puts <<~DESC
+        The console will start a PRY session inside the Engine class which provides access to the IBM Cloud SDK.
+
+        To access the SDK use the following methods without options:
+          * vpc to get an instance of the VPC API.
+          * power to get an instance of the Power API.
+      DESC
+    end
+
+    def initialize(api_key = nil, logger: nil, options: {}, cli_options: {})
+      @logger = logger
+      @logger ||= Logger.new($stdout, level: :warn)
+      @client = HTTP.use(http_options(options))
+      _set_variables(cli_options)
+      @api_key ||= api_key
+      raise 'API Key must be set.' unless @api_key
+
+      @connection = IBM::Cloud::SDK::VPC::Connection.new(@api_key, logger: @logger, client: @client)
+    end
+
+    def http_options(options = {})
+      options.merge(
+        {
+          logging: { logger: @logger },
+          auto_deflate: {}
+        }
+      )
+    end
+
+    attr_reader :logger, :connection
+
+    def power(region = nil, guid = nil, crn = nil, tenant = nil)
+      _set_variables({ region: region, quid: guid, crn: crn, tenant: tenant })
+      IBM::Cloud::SDK::PowerIaas.new(@region, @guid, @connection, @crn, @tenant) if required %w[region guid crn tenant]
+    end
+
+    def vpc(region = 'us-east')
+      _set_variables({ region: region })
+      IBM::Cloud::SDK::Vpc.new(@region, @connection, logger: @logger) if required %w[region]
+    end
+
+    private
+
+    def required(values)
+      empty_values = []
+      values.each do |v|
+        empty_values.push(v) unless instance_variable_get("@#{v}")
       end
-
-      def http_options(options = {})
-        options.merge(
-          {
-            logging: { logger: @logger },
-            auto_deflate: {}
-          }
-        )
+      if empty_values.length.positive?
+        puts "Values required for options #{empty_values.join(', ')} to continue."
+        return false
       end
+      true
+    end
 
-      attr_reader :logger, :connection
-
-      def vpc(region = 'us-east')
-        IBM::Cloud::SDK::Vpc.new(region, @connection, logger: @logger)
+    def _set_variables(options)
+      options.each do |k, v|
+        instance_variable_set("@#{k}", v) unless v.nil? || v.empty?
       end
     end
+  end
 end

--- a/lib/ibm/cloud/sdk/vpc/helpers/connection.rb
+++ b/lib/ibm/cloud/sdk/vpc/helpers/connection.rb
@@ -8,7 +8,6 @@ module IBM
   module Cloud
     module SDK
       module VPC
-
         # Contols tokens.
         class Connection
           def initialize(api_key, logger: nil, client: nil)
@@ -36,7 +35,7 @@ module IBM
             @api_key = api_key
             @logger = logger
             @client = client
-            @data = fetch
+            @data = nil
           end
 
           def fetch


### PR DESCRIPTION
Allows for saving all variables into a sourced shell script.
Default sets up the CloudSDK. Reads settings from env variables.
Easy entry into vpc and power sdks.

Updates development dependencies.

Commands
```
ibm-cloud-sdk-ruby > bin/console --help
Commands:
  console cli               # Start a Cloud SDK CLI
  console help [COMMAND]    # Describe available commands or one specific command
  console variables output  # Save the options to a Envionrment variables source file.

Options:
  [--api-key=API_KEY]  # The API Key to log into IBM Cloud Environemnt Variable: 
  [--region=REGION]    # The region to connect to Environemnt Variable: us-east
                       # Default: us-east
  [--crn=CRN]          # The CRN for the region. Environemnt Variable: 
  [--guid=GUID]        # The GUID for the power env. Environemnt Variable: 
  [--tenant=TENANT]    # The tenant for the region. Environemnt Variable: 
```

WIth environment variables set there is no need to set command line options.
```
ibm-cloud-sdk-ruby > bin/console
The console will start a PRY session inside the Engine class which provides access to the IBM Cloud SDK.

To access the SDK use the following methods without options:
  * vpc to get an instance of the VPC API.
  * power to get an instance of the Power API.
[1] pry(#<IBM::CloudSDK>)> 
```