### PR TITLE
Return region specific PowerVS storage types

### DIFF
--- a/lib/ibm/cloud/sdk/power_iaas.rb
+++ b/lib/ibm/cloud/sdk/power_iaas.rb
@@ -159,7 +159,7 @@ module IBM
         #
         # @return [Hash] StorageType
         def get_storage_types
-          JSON.parse(RestClient.get("https://#{region.sub(/-\d$/, '')}.power-iaas.cloud.ibm.com/broker/v1/storage-types", headers))
+          JSON.parse(RestClient.get("https://#{region.sub(/-\d$/, '')}.power-iaas.cloud.ibm.com/broker/v1/storage-types", headers))[region]
         end
 
         def create_network(network_hash)


### PR DESCRIPTION
PowerIaas objects are bound to the power cloud instance region. This
'get_storage_types' call to the broker API is (hopefully) ephemeral, and
it's replacement should only return storage types available in the
instance region.

If we parse this with in the method now, then we can drop in the
replacement API later without change the return data structure.

Required for https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/40