### PR TITLE
Log ResourceController and IAM calls

### DIFF
--- a/lib/ibm/cloud/sdk/iam.rb
+++ b/lib/ibm/cloud/sdk/iam.rb
@@ -1,13 +1,18 @@
+require_relative 'logging'
+
 module IBM
   module Cloud
     module SDK
       class IAM < BaseService
+        include Logging
+
         def endpoint
           "https://iam.cloud.ibm.com".freeze
         end
 
         def initialize(api_key)
           @api_key = api_key
+          RestClient.log = logger
         end
 
         def get_identity_token

--- a/lib/ibm/cloud/sdk/resource_controller.rb
+++ b/lib/ibm/cloud/sdk/resource_controller.rb
@@ -1,7 +1,10 @@
+require_relative 'logging'
+
 module IBM
   module Cloud
     module SDK
       class ResourceController < BaseService
+        include Logging
         require "ibm/cloud/sdk/resource_controller/resource"
         def endpoint
           "https://resource-controller.cloud.ibm.com/v2"
@@ -9,6 +12,7 @@ module IBM
 
         def initialize(token)
           @token = token
+          RestClient.log = logger
         end
 
         def get_resource(guid)


### PR DESCRIPTION
API calls made from the 'IAM' and 'ResourceController' classes should be
logged in the same way as 'PowerIaas' (implemented in d3d4dfe).

Depends on:
- [x] ManageIQ/manageiq#20675