### PR TITLE
Return self after refresh.

### DIFF
--- a/lib/ibm/cloud/sdk_http/base_instance.rb
+++ b/lib/ibm/cloud/sdk_http/base_instance.rb
@@ -34,6 +34,7 @@ module IBM
         # @return [BaseInstance] This instance for chaining.
         def refresh
           @data.replace(details)
+          self
         end
 
         # Send an update to the server for this resource.


### PR DESCRIPTION
Refreshing instance is supposed to return the class. It returns the data hash right now.