### PR TITLE
empty crn returns empty list on attached_to

### DIFF
--- a/lib/ibm/cloud/sdk/tags/http/tag_collection.rb
+++ b/lib/ibm/cloud/sdk/tags/http/tag_collection.rb
@@ -62,7 +62,7 @@ module IBM
           # Get all tags attached to a CRN.
           # @param crn [String] The CRN for the instance.
           def attached_to(crn)
-            return [] if crn.empty?
+            return [] if crn.to_s.empty?
 
             params(attached_to: crn).all
           end

--- a/lib/ibm/cloud/sdk/tags/http/tag_collection.rb
+++ b/lib/ibm/cloud/sdk/tags/http/tag_collection.rb
@@ -62,6 +62,8 @@ module IBM
           # Get all tags attached to a CRN.
           # @param crn [String] The CRN for the instance.
           def attached_to(crn)
+            return [] if crn.empty?
+
             params(attached_to: crn).all
           end
 

--- a/spec/ibm/cloud/sdk/tags_spec.rb
+++ b/spec/ibm/cloud/sdk/tags_spec.rb
@@ -49,4 +49,11 @@ RSpec.describe IBM::Cloud::SDK::Tags, vcr: { tag: :require_2xx } do
     t.reset_params
     expect(t.instance_variable_get(:@params).length).to eq(0)
   end
+
+  it 'instance_of returns empty list when param empty.' do
+    expect(tags.attached_to(nil)).to be_an_instance_of(Array)
+    expect(tags.attached_to(nil).empty?).to be true
+    expect(tags.attached_to('')).to be_an_instance_of(Array)
+    expect(tags.attached_to('').empty?).to be true
+  end
 end


### PR DESCRIPTION
On attached_to an empty CRN would return all tags. This guards against that.