### PR TITLE
Instance actions

### DIFF
--- a/lib/ibm/cloud/sdk/vpc/http/vpc_http.rb
+++ b/lib/ibm/cloud/sdk/vpc/http/vpc_http.rb
@@ -11,16 +11,10 @@ module IBM
         module VpcHTTP
           include SDKHTTP::BaseHTTPMixin
 
-          def metadata(query = nil, payload = nil)
-            @params ||= {}
-            @params.merge!(query) if query
-
-            payload ||= {}
-            {
-              query: { version: '2020-08-01', generation: 2 }.merge(@params),
-              body: payload,
-              headers: { "Authorization": @token.authorization_header }
-            }
+          def metadata(query = nil, payload = nil, payload_type = 'json')
+            default_params = { version: '2020-08-01', generation: 2 }
+            default_params.merge!(query) if query
+            super(default_params, payload, payload_type)
           end
         end
       end

--- a/lib/ibm/cloud/sdk/vpc/http/vpc_http.rb
+++ b/lib/ibm/cloud/sdk/vpc/http/vpc_http.rb
@@ -11,6 +11,11 @@ module IBM
         module VpcHTTP
           include SDKHTTP::BaseHTTPMixin
 
+          # Preprocess request parameters, add required version and generation parameters to query.
+          # @param query [Hash] A hash of query parameters.
+          # @param payload [Hash] A hash to send as the body.
+          # @param payload_type [Hash] If json then convert to json string, else send as form data.
+          # @return [Hash]
           def metadata(query = nil, payload = nil, payload_type = 'json')
             default_params = { version: '2020-08-01', generation: 2 }
             default_params.merge!(query) if query

--- a/lib/ibm/cloud/sdk/vpc/instance/actions.rb
+++ b/lib/ibm/cloud/sdk/vpc/instance/actions.rb
@@ -1,6 +1,9 @@
 # typed: true
 # frozen_string_literal: true
 
+require 'date'
+require 'forwardable'
+
 module IBM
   module Cloud
     module SDK
@@ -10,6 +13,67 @@ module IBM
           class Actions < VPCCollection
             def initialize(parent)
               super(parent, 'actions')
+            end
+
+            # Send an action request to start the instance.
+            def start
+              send_action('start')
+            end
+
+            # Send an action request to stop the instance.
+            # @param force [Boolean] Clear the queue and run this action.
+            def stop(force: false)
+              send_action('stop', force: force)
+            end
+
+            # Send an action request to reboot the instance.
+            # @param force [Boolean] Clear the queue and run this action.
+            def reboot(force: false)
+              send_action('reboot', force: force)
+            end
+
+            # Send a custom action request.
+            # @param action [String] The type of action. Allowable values: [reboot, start, stop]
+            # @param force [Boolean] If set to true, the action will be forced immediately, and all queued actions deleted. Ignored for the start action.
+            def send_action(action, force: false)
+              payload = { type: action }
+              payload[:force] = force if force
+              response = post(payload: payload)
+              Action.new(response)
+            end
+          end
+
+          # A base class that wraps the action response.
+          class Action
+            def initialize(response)
+              @response = response
+              @data = response.json
+              @keys = %i[type force created_at]
+              add_inst_vars(@keys)
+            end
+
+            # Return the DateTime the action was created.
+            # @return [DateTime]
+            def created_at
+              return DateTime.parse(@created_at) if @created_at
+
+              @created_at
+            end
+
+            # The HTTP response object.
+            attr_accessor :response
+
+            extend Forwardable
+            def_delegators :@data, :[], :dig, :each_pair, :fetch, :has_key?, :has_value?, :include?, :index, :inspect, :key?, :keys, :length, :merge, :merge!, :clear, :to_h, :value?, :values, :pretty_print
+
+            private
+
+            # Iterate through an array of symbols. Set the instance variable and attr_accessor for each.
+            def add_inst_vars(keys)
+              keys.each do |k|
+                instance_variable_set "@#{k}", @data[k]
+                self.class.attr_accessor k unless respond_to?(k)
+              end
             end
           end
         end

--- a/lib/ibm/cloud/sdk/vpc/instance/actions.rb
+++ b/lib/ibm/cloud/sdk/vpc/instance/actions.rb
@@ -17,25 +17,26 @@ module IBM
 
             # Send an action request to start the instance.
             def start
-              send_action('start')
+              create('start')
             end
 
             # Send an action request to stop the instance.
             # @param force [Boolean] Clear the queue and run this action.
             def stop(force: false)
-              send_action('stop', force: force)
+              create('stop', force: force)
             end
 
             # Send an action request to reboot the instance.
             # @param force [Boolean] Clear the queue and run this action.
             def reboot(force: false)
-              send_action('reboot', force: force)
+              create('reboot', force: force)
             end
 
             # Send a custom action request.
             # @param action [String] The type of action. Allowable values: [reboot, start, stop]
             # @param force [Boolean] If set to true, the action will be forced immediately, and all queued actions deleted. Ignored for the start action.
-            def send_action(action, force: false)
+            def create(action, force: false)
+              @logger.info("Sending action request for #{action} with force #{force}.")
               payload = { type: action }
               payload[:force] = force if force
               response = post(payload: payload)

--- a/lib/ibm/cloud/sdk/vpc/instance/actions.rb
+++ b/lib/ibm/cloud/sdk/vpc/instance/actions.rb
@@ -49,6 +49,9 @@ module IBM
               @response = response
               @data = response.json
               @keys = %i[type force created_at]
+              @deprecated = %i[completed_at started_at status id href]
+
+              clear_deprecated
               add_inst_vars(@keys)
             end
 
@@ -61,10 +64,10 @@ module IBM
             end
 
             # The HTTP response object.
-            attr_accessor :response
+            attr_accessor :response, :data
 
             extend Forwardable
-            def_delegators :@data, :[], :dig, :each_pair, :fetch, :has_key?, :has_value?, :include?, :index, :inspect, :key?, :keys, :length, :merge, :merge!, :clear, :to_h, :value?, :values, :pretty_print
+            def_delegators :@data, :[], :dig, :each_pair, :each, :fetch, :has_key?, :has_value?, :include?, :index, :inspect, :key?, :keys, :length, :merge, :merge!, :clear, :to_h, :value?, :values, :pretty_print
 
             private
 
@@ -73,6 +76,13 @@ module IBM
               keys.each do |k|
                 instance_variable_set "@#{k}", @data[k]
                 self.class.attr_accessor k unless respond_to?(k)
+              end
+            end
+
+            # Remove deprecated keys from hash.
+            def clear_deprecated
+              @data.each do |k, _v|
+                @data.delete(k) if @deprecated.include?(k)
               end
             end
           end

--- a/lib/ibm/cloud/sdk/vpc/instances.rb
+++ b/lib/ibm/cloud/sdk/vpc/instances.rb
@@ -38,10 +38,10 @@ module IBM
 
         # Work with a single instance.
         class Instance < VPCInstance
-          TRANSITIONAL_STATES = %(pausing pending restarting resuming starting stopping)
+          TRANSITIONAL_STATES = %w[pausing pending restarting resuming starting stopping].freeze
           ERROR_STATE = 'failed'
           RUNNING_STATE = 'running'
-          STOPPED_STATES = %('stopped', 'paused')
+          STOPPED_STATES = %w[stopped paused].freeze
 
           # The id of this VM.
           def id

--- a/lib/ibm/cloud/sdk/vpc/instances.rb
+++ b/lib/ibm/cloud/sdk/vpc/instances.rb
@@ -109,6 +109,7 @@ module IBM
           # @param started [Boolean] When true wait for started, when false wait for stopped.
           # @param sleep_time [Integer] The time to sleep between refreshes.
           # @param timeout [Integer] The number of seconds before raising an error.
+          # @param block [Proc] A block to test against. Must return a boolean.
           # @return [Boolean] The return of the status check.
           # @raise [RuntimeError] Instance goes into failed state.
           # @raise [RuntimeError] Timeout has been reached.

--- a/lib/ibm/cloud/sdk/vpc/instances.rb
+++ b/lib/ibm/cloud/sdk/vpc/instances.rb
@@ -110,7 +110,6 @@ module IBM
           # @param sleep_time [Integer] The time to sleep between refreshes.
           # @param timeout [Integer] The number of seconds before raising an error.
           # @param block [Proc] A block to test against. Must return a boolean.
-          # @return [Boolean] The return of the status check.
           # @raise [RuntimeError] Instance goes into failed state.
           # @raise [RuntimeError] Timeout has been reached.
           def wait_for(started: true, sleep_time: 5, timeout: 600, &block)
@@ -122,7 +121,6 @@ module IBM
               raise "Time out while waiting #{id} to be stable." if timeout <= 0
             end
             @logger.info("Finished wait for instance #{id} ends in state #{status}.")
-            test_state(&block)
           end
 
           private

--- a/lib/ibm/cloud/sdk/vpc/instances.rb
+++ b/lib/ibm/cloud/sdk/vpc/instances.rb
@@ -111,7 +111,7 @@ module IBM
           # @param block [Proc] A block to test against. Must return a boolean.
           # @raise [RuntimeError] Instance goes into failed state.
           # @raise [RuntimeError] Timeout has been reached.
-          def wait_for(sleep_time: 5, timeout: 600, &block)
+          def wait_for!(sleep_time: 5, timeout: 600, &block)
             @logger.info("Starting wait for instance #{id}. Starts in state #{status}.")
             loop do
               refresh
@@ -127,15 +127,19 @@ module IBM
           # Wait for the VM instance to be have a started status.
           # @param sleep_time [Integer] The time to sleep between refreshes.
           # @param timeout [Integer] The number of seconds before raising an error.
-          def wait_for_started(sleep_time: 5, timeout: 600)
-            wait_for(sleep_time: sleep_time, timeout: timeout, &:started?)
+          # @raise [RuntimeError] Instance goes into failed state.
+          # @raise [RuntimeError] Timeout has been reached.
+          def wait_for_started!(sleep_time: 5, timeout: 600)
+            wait_for!(sleep_time: sleep_time, timeout: timeout, &:started?)
           end
 
           # Wait for the VM instance to be have a stopped status.
           # @param sleep_time [Integer] The time to sleep between refreshes.
           # @param timeout [Integer] The number of seconds before raising an error.
-          def wait_for_stopped(sleep_time: 5, timeout: 600)
-            wait_for(sleep_time: sleep_time, timeout: timeout, &:stopped?)
+          # @raise [RuntimeError] Instance goes into failed state.
+          # @raise [RuntimeError] Timeout has been reached.
+          def wait_for_stopped!(sleep_time: 5, timeout: 600)
+            wait_for!(sleep_time: sleep_time, timeout: timeout, &:stopped?)
           end
 
           private

--- a/lib/ibm/cloud/sdk/vpc/instances.rb
+++ b/lib/ibm/cloud/sdk/vpc/instances.rb
@@ -78,7 +78,7 @@ module IBM
 
           # Whether the state of the VM is in a transitional state.
           # @return [Boolean]
-          def transtional?
+          def transitional?
             TRANSITIONAL_STATES.include?(status)
           end
 

--- a/lib/ibm/cloud/sdk/vpc/vpn_gateway/local_cidrs.rb
+++ b/lib/ibm/cloud/sdk/vpc/vpn_gateway/local_cidrs.rb
@@ -22,7 +22,7 @@ module IBM
           # A single Connection
           class LocalCIDR < VPCInstance
             def update(payload)
-              put(payload)
+              put(payload: payload)
             end
           end
         end

--- a/lib/ibm/cloud/sdk/vpc/vpn_gateway/peer_cidrs.rb
+++ b/lib/ibm/cloud/sdk/vpc/vpn_gateway/peer_cidrs.rb
@@ -22,7 +22,7 @@ module IBM
           # A single Connection
           class PeerCIDR < VPCInstance
             def update(payload)
-              put(payload)
+              put(payload: payload)
             end
           end
         end

--- a/lib/ibm/cloud/sdk_http/base_http_mixin.rb
+++ b/lib/ibm/cloud/sdk_http/base_http_mixin.rb
@@ -10,36 +10,86 @@ module IBM
       module BaseHTTPMixin
         @connection = nil
 
+        # Run a custom query and verify response is 2xx or 404.
+        # @param method [String] The HTTP method to use.
+        # @param path [String] The relative path from the current object location.
+        # @param params [Hash] A hash of query parameters.
+        # @param payload [Hash] A hash to send as the body.
+        # @param payload_type [Hash] If json then convert to json string, else send as form data.
+        # @return [SDKResponse]
+        # @raise [Exceptions::HttpStatusError] Raise if status checks failed.
         def adhoc(method: 'get', path: nil, params: nil, payload: nil, payload_type: 'json')
           unchecked_response(method: method, path: path, params: params, payload: payload, payload_type: payload_type).raise_for_status!
         end
 
+        # Run a custom query do not verify the response.
+        # @param method [String] The HTTP method to use.
+        # @param path [String] The relative path from the current object location.
+        # @param params [Hash] A hash of query parameters.
+        # @param payload [Hash] A hash to send as the body.
+        # @param payload_type [Hash] If json then convert to json string, else send as form data.
         def unchecked_response(method: 'get', path: nil, params: nil, payload: nil, payload_type: 'json')
           @connection.request(method.to_sym, url(path), metadata(params, payload, payload_type))
         end
 
         attr_reader :endpoint
 
+        # Perform a GET request and verify response is 2xx or 404.
+        # @param path [String] The relative path from the current object location.
+        # @param params [Hash] A hash of query parameters.
+        # @return [SDKResponse]
+        # @raise [Exceptions::HttpStatusError] Raise if status checks failed.
         def get(path: nil, params: nil)
           adhoc(method: 'get', path: path, params: params)
         end
 
+        # Send a POST request and verify response is 2xx or 404.
+        # @param path [String] The relative path from the current object location.
+        # @param params [Hash] A hash of query parameters.
+        # @param payload [Hash] A hash to send as the body.
+        # @param payload_type [Hash] If json then convert to json string, else send as form data.
+        # @raise [Exceptions::HttpStatusError] Raise if status checks failed.
+        # @return [SDKResponse]
         def post(payload: nil, path: nil, params: nil, payload_type: 'json')
           adhoc(method: 'post', path: path, params: params, payload: payload, payload_type: payload_type)
         end
 
+        # Send a PUT request and verify response is 2xx or 404.
+        # @param path [String] The relative path from the current object location.
+        # @param params [Hash] A hash of query parameters.
+        # @param payload [Hash] A hash to send as the body.
+        # @param payload_type [Hash] If json then convert to json string, else send as form data.
+        # @raise [Exceptions::HttpStatusError] Raise if status checks failed.
+        # @return [SDKResponse]
         def put(payload: nil, path: nil, params: nil, payload_type: 'json')
           adhoc(method: 'put', path: path, params: params, payload: payload, payload_type: payload_type)
         end
 
+        # Send a PATCH request and verify response is 2xx or 404.
+        # @param path [String] The relative path from the current object location.
+        # @param params [Hash] A hash of query parameters.
+        # @param payload [Hash] A hash to send as the body.
+        # @param payload_type [Hash] If json then convert to json string, else send as form data.
+        # @raise [Exceptions::HttpStatusError] Raise if status checks failed.
+        # @return [SDKResponse]
         def patch(payload: nil, path: nil, params: nil, payload_type: 'json')
           adhoc(method: 'patch', path: path, params: params, payload: payload, payload_type: payload_type)
         end
 
+        # Send a DELETE request and verify response is 2xx or 404.
+        # @param path [String] The relative path from the current object location.
+        # @param params [Hash] A hash of query parameters.
+        # @raise [Exceptions::HttpStatusError] Raise if status checks failed.
+        # @return [SDKResponse]
         def delete(path: nil, params: nil)
           adhoc(method: 'delete', path: path, params: params)
         end
 
+        # Preprocess request parameters with any additional data.
+        # @param query [Hash] A hash of query parameters.
+        # @param payload [Hash] A hash to send as the body.
+        # @param payload_type [Hash] If json then convert to json string, else send as form data.
+        # @return [Hash]
         def metadata(query = nil, payload = nil, payload_type = 'json')
           @params ||= {}
           @params.merge!(query) if query
@@ -57,6 +107,7 @@ module IBM
           send_parameters
         end
 
+        # Merge path with current class's endpoint.
         def url(path = nil)
           return endpoint unless path
           return path if URI.parse(path).relative? == false

--- a/lib/ibm/cloud/sdk_http/base_http_mixin.rb
+++ b/lib/ibm/cloud/sdk_http/base_http_mixin.rb
@@ -10,45 +10,51 @@ module IBM
       module BaseHTTPMixin
         @connection = nil
 
-        def adhoc(method: 'get', path: nil, params: {}, payload: {})
+        def adhoc(method: 'get', path: nil, params: nil, payload: nil)
           unchecked_response(method: method, path: path, params: params, payload: payload).raise_for_status!
         end
 
-        def unchecked_response(method: 'get', path: nil, params: {}, payload: {})
+        def unchecked_response(method: 'get', path: nil, params: nil, payload: nil)
           @connection.request(method.to_sym, url(path), metadata(params, payload))
         end
 
-        def get(path: nil, params: {})
+        def get(path: nil, params: nil)
           adhoc(method: 'get', path: path, params: params)
         end
 
         attr_reader :endpoint
 
-        def post(payload = {}, path: nil, params: {})
+        def post(payload: nil, path: nil, params: nil)
           adhoc(method: 'post', path: path, params: params, payload: payload)
         end
 
-        def put(payload = {}, path: nil, params: {})
+        def put(payload: nil, path: nil, params: nil)
           adhoc(method: 'put', path: path, params: params, payload: payload)
         end
 
-        def patch(payload = {},  path: nil, params: {})
+        def patch(payload: nil, path: nil, params: nil)
           adhoc(method: 'patch', path: path, params: params, payload: payload)
         end
 
-        def delete(path: nil, params: {})
+        def delete(path: nil, params: nil)
           adhoc(method: 'delete', path: path, params: params)
         end
 
-        def metadata(query = nil, payload = nil)
+        def metadata(query = nil, payload = nil, payload_type = 'json')
           @params ||= {}
-          query ||= {}
-          payload ||= {}
-          {
-            query: @params.merge(query),
-            body: payload,
+          @params.merge!(query) if query
+
+          send_parameters = {
+            query: @params,
             headers: { "Authorization": @token.authorization_header }
           }
+
+          # Add payload if it is not nil.
+          if payload && payload.empty? == false
+            payload = payload.to_json if payload_type == 'json'
+            send_parameters[:body] = payload
+          end
+          send_parameters
         end
 
         def url(path = nil)

--- a/lib/ibm/cloud/sdk_http/base_http_mixin.rb
+++ b/lib/ibm/cloud/sdk_http/base_http_mixin.rb
@@ -10,30 +10,30 @@ module IBM
       module BaseHTTPMixin
         @connection = nil
 
-        def adhoc(method: 'get', path: nil, params: nil, payload: nil)
-          unchecked_response(method: method, path: path, params: params, payload: payload).raise_for_status!
+        def adhoc(method: 'get', path: nil, params: nil, payload: nil, payload_type: 'json')
+          unchecked_response(method: method, path: path, params: params, payload: payload, payload_type: payload_type).raise_for_status!
         end
 
-        def unchecked_response(method: 'get', path: nil, params: nil, payload: nil)
-          @connection.request(method.to_sym, url(path), metadata(params, payload))
+        def unchecked_response(method: 'get', path: nil, params: nil, payload: nil, payload_type: 'json')
+          @connection.request(method.to_sym, url(path), metadata(params, payload, payload_type))
         end
+
+        attr_reader :endpoint
 
         def get(path: nil, params: nil)
           adhoc(method: 'get', path: path, params: params)
         end
 
-        attr_reader :endpoint
-
-        def post(payload: nil, path: nil, params: nil)
-          adhoc(method: 'post', path: path, params: params, payload: payload)
+        def post(payload: nil, path: nil, params: nil, payload_type: 'json')
+          adhoc(method: 'post', path: path, params: params, payload: payload, payload_type: payload_type)
         end
 
-        def put(payload: nil, path: nil, params: nil)
-          adhoc(method: 'put', path: path, params: params, payload: payload)
+        def put(payload: nil, path: nil, params: nil, payload_type: 'json')
+          adhoc(method: 'put', path: path, params: params, payload: payload, payload_type: payload_type)
         end
 
-        def patch(payload: nil, path: nil, params: nil)
-          adhoc(method: 'patch', path: path, params: params, payload: payload)
+        def patch(payload: nil, path: nil, params: nil, payload_type: 'json')
+          adhoc(method: 'patch', path: path, params: params, payload: payload, payload_type: payload_type)
         end
 
         def delete(path: nil, params: nil)

--- a/lib/ibm/cloud/sdk_http/base_instance.rb
+++ b/lib/ibm/cloud/sdk_http/base_instance.rb
@@ -39,7 +39,7 @@ module IBM
 
         # Send an update to the server for this resource.
         def update(payload)
-          patch(payload)
+          patch(payload: payload)
         end
 
         # Send a delete request to the server for this resource.

--- a/lib/ibm/cloud/sdk_http/connection.rb
+++ b/lib/ibm/cloud/sdk_http/connection.rb
@@ -11,7 +11,13 @@ module IBM
         include HTTParty
 
         def initialize(logger)
-          self.class.logger(logger, :debug, :curl)
+          @logger = logger
+          self.class.logger(logger, :debug, :apache)
+        end
+
+        # Set the logger type to curl which has more information.
+        def verbose_logger=(verbosity)
+          default_options[:log_format] = verbosity ? :curl : :apache
         end
 
         def default_options


### PR DESCRIPTION
Fixes general issues with the way body payloads were generated.
Adds stop, start, reboot actions on the instance.
Also adds status test methods and a wait_for method to instance.
wait_for blocks until instance is in either stopped or started states depending on parameters.
