### PR TITLE
WIP - wait_for that returns status and message.

### DIFF
--- a/lib/ibm/cloud/sdk/vpc/instances.rb
+++ b/lib/ibm/cloud/sdk/vpc/instances.rb
@@ -109,19 +109,32 @@ module IBM
           # @param sleep_time [Integer] The time to sleep between refreshes.
           # @param timeout [Integer] The number of seconds before raising an error.
           # @param block [Proc] A block to test against. Must return a boolean.
-          # @raise [RuntimeError] Instance goes into failed state.
-          # @raise [RuntimeError] Timeout has been reached.
-          def wait_for!(sleep_time: 5, timeout: 600, &block)
+          # @return [Array] Status of operation and informational message.
+          def wait_for(sleep_time: 5, timeout: 600, &block)
             @logger.info("Starting wait for instance #{id}. Starts in state #{status}.")
             loop do
               refresh
-              raise "VM #{id} is in a failed state." if failed?
+              return [false, "VM #{id} is in a failed state."] if failed?
               break if block.call(self)
 
               timeout = sleep_counter(sleep_time, timeout)
-              raise "Time out while waiting #{id} to be stable." if timeout <= 0
+              return [false, "Time out while waiting #{id} to be stable."] if timeout <= 0
             end
             @logger.info("Finished wait for instance #{id}. Ends in state #{status}.")
+            [true, 'ok']
+          end
+
+          # Wait for the VM instance to be in a stable state. Raise on error.
+          # @param sleep_time [Integer] The time to sleep between refreshes.
+          # @param timeout [Integer] The number of seconds before raising an error.
+          # @param block [Proc] A block to test against. Must return a boolean.
+          # @raise [RuntimeError] Instance goes into failed state.
+          # @raise [RuntimeError] Timeout has been reached.
+          def wait_for!(sleep_time: 5, timeout: 600, &block)
+            status, msg = wait_for(sleep_time: sleep_time, timeout: timeout, &block)
+            return if status
+
+            raise msg
           end
 
           # Wait for the VM instance to be have a started status.


### PR DESCRIPTION
For if we decide that we don't want to do a rescue in vm reboot's wait_for transitional status.

* wait_for returns a boolean status and string message in array.
* wait_for! uses wait_for and raises on error.