### PR TITLE
Add empty string to valid 'proc_type' values

### DIFF
--- a/gems/ibm_cloud_power/lib/ibm_cloud_power/models/pvm_instance.rb
+++ b/gems/ibm_cloud_power/lib/ibm_cloud_power/models/pvm_instance.rb
@@ -436,7 +436,7 @@ module IbmCloudPower
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] proc_type Object to be assigned
     def proc_type=(proc_type)
-      validator = EnumAttributeValidator.new('String', ["dedicated", "shared", "capped"])
+      validator = EnumAttributeValidator.new('String', ["dedicated", "shared", "capped", ""])
       unless validator.valid?(proc_type)
         fail ArgumentError, "invalid value for \"proc_type\", must be one of #{validator.allowable_values}."
       end


### PR DESCRIPTION
When a VSI's status is 'BUILD' the Power Cloud API returns an empty
string as the 'procType' value, which does not follow the current
OpenAPI definition.

fixes #48 

I believe this is ultimately a bug in the Power Cloud API backend and am following up with the API team internally within IBM. I'm not sure how long a fix would take, so this is proposed as a interim fix.