### PR TITLE
Add ibm-derived resource manager gem

### DIFF
--- a/gems/ibm_cloud_resource_manager/.bumpversion.cfg
+++ b/gems/ibm_cloud_resource_manager/.bumpversion.cfg
@@ -1,0 +1,13 @@
+[bumpversion]
+current_version = 0.0.1
+commit = True
+message = Update version {current_version} -> {new_version}
+
+[bumpversion:file:lib/ibm_cloud_resource_manager/version.rb]
+search = VERSION = '{current_version}'
+replace = VERSION = '{new_version}'
+
+[bumpversion:file:README.md]
+search = {current_version}
+replace = {new_version}
+

--- a/gems/ibm_cloud_resource_manager/.gitignore
+++ b/gems/ibm_cloud_resource_manager/.gitignore
@@ -1,0 +1,13 @@
+/*.gem
+/.bundle/
+/.yardoc
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+/Gemfile.lock
+
+# rspec failure tracking
+.rspec_status

--- a/gems/ibm_cloud_resource_manager/.rspec
+++ b/gems/ibm_cloud_resource_manager/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--require spec_helper

--- a/gems/ibm_cloud_resource_manager/.secrets.baseline
+++ b/gems/ibm_cloud_resource_manager/.secrets.baseline
@@ -1,0 +1,72 @@
+{
+  "exclude": {
+    "files": "^.secrets.baseline$",
+    "lines": null
+  },
+  "generated_at": "2021-02-25T12:35:57Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "GheDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {},
+  "version": "0.13.1+ibm.29.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/gems/ibm_cloud_resource_manager/.travis.yml
+++ b/gems/ibm_cloud_resource_manager/.travis.yml
@@ -1,0 +1,49 @@
+language: ruby
+dist: trusty
+cache: bundler
+
+notifications:
+  email: true
+
+matrix:
+  fast_finish: true 
+
+before_install:
+  - git fetch --tags
+  - sudo apt-get update
+  - sudo apt-get install python
+  - nvm install node
+  - nvm use node
+  - gem install bundler:1.16.3
+
+install:
+  - bundle _1.16.3_ install
+
+script:
+- bundle exec rake
+
+# To enable semantic-release, uncomment these sections.
+# before_deploy:
+#  - pip install --user bumpversion
+#  - npm install -g semantic-release
+#  - npm install -g @semantic-release/changelog
+#  - npm install -g @semantic-release/exec
+#  - npm install -g @semantic-release/git
+#  - npm install -g @semantic-release/github
+#  - npm install -g @semantic-release/commit-analyzer
+# 
+# deploy:
+# - provider: script
+#   script: npx semantic-release
+#   skip_cleanup: true
+#   on:
+#     branch: main
+#     rvm: 2.5.1
+#
+# - provider: rubygems
+#   api_key: $RUBYGEMS_API_KEY
+#   gem: ibm_cloud_resource_manager
+#   on:
+#     rvm: '2.5.1'
+#     branch: main
+#

--- a/gems/ibm_cloud_resource_manager/CHANGELOG.md
+++ b/gems/ibm_cloud_resource_manager/CHANGELOG.md
@@ -1,0 +1,2 @@
+= 0.0.1
+* Initial release

--- a/gems/ibm_cloud_resource_manager/CODE_OF_CONDUCT.md
+++ b/gems/ibm_cloud_resource_manager/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at phil_adams@us.ibm.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/gems/ibm_cloud_resource_manager/CONTRIBUTING.md
+++ b/gems/ibm_cloud_resource_manager/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Questions
+If you are having problems using the APIs or have a question about IBM Cloud services,
+please ask a question at
+[Stack Overflow](http://stackoverflow.com/questions/ask?tags=ibm-cloud).
+
+# Issues
+If you encounter an issue with the project, you are welcome to submit a
+[bug report](https://github.com/IBM-Cloud/ibm-cloud-sdk-ruby/issues).
+Before that, please search for similar issues. It's possible that someone has already reported the problem.
+
+# General Information
+For general guidance on contributing to this project, please see
+[this link](https://github.com/IBM/ibm-cloud-sdk-common/blob/main/CONTRIBUTING_ruby.md)

--- a/gems/ibm_cloud_resource_manager/Gemfile
+++ b/gems/ibm_cloud_resource_manager/Gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in ibm_cloud_resource_manager.gemspec
+gemspec
+
+gem 'rake', '~> 12.0'
+gem 'rspec', '~> 3.0'

--- a/gems/ibm_cloud_resource_manager/LICENSE
+++ b/gems/ibm_cloud_resource_manager/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/gems/ibm_cloud_resource_manager/README.md
+++ b/gems/ibm_cloud_resource_manager/README.md
@@ -1,0 +1,116 @@
+[![Build Status](https://travis-ci.com/IBM/vpc-ruby-sdk.svg?token=eW5FVD71iyte6tTby8gr&branch=master)](https://travis.ibm.com/IBM/vpc-ruby-sdk)
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
+# IBM Cloud Resource Manager Ruby SDK
+
+Ruby client library to interact with various [IBM Cloud Resource Manager APIs](https://cloud.ibm.com/apidocs?category=compute).
+
+Disclaimer: this SDK is being released initially as a **pre-release** version.
+Changes might occur which impact applications that use this SDK.
+
+## Table of Contents
+
+<!--
+  The TOC below is generated using the `markdown-toc` node package.
+
+      https://github.com/jonschlinkert/markdown-toc
+
+  You should regenerate the TOC after making changes to this file.
+
+      npx markdown-toc -i README.md
+  -->
+
+<!-- toc -->
+
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [Using the SDK](#using-the-sdk)
+- [Questions](#questions)
+- [Issues](#issues)
+- [Open source @ IBM](#open-source--ibm)
+- [Contributing](#contributing)
+- [License](#license)
+
+<!-- tocstop -->
+
+## Overview
+
+The IBM Cloud Resource Manager Ruby SDK allows developers to programmatically interact with the following
+IBM Cloud services:
+
+Service Name | Imported Class Name
+--- | ---
+[Resource Manager](https://cloud.ibm.com/apidocs/resource-controller/resource-manager) | IbmCloudResourceManager::ResourceManagerV2
+
+## Prerequisites
+
+[ibm-cloud-onboarding]: https://cloud.ibm.com/registration
+
+* An [IBM Cloud][ibm-cloud-onboarding] account.
+* An IAM API key to allow the SDK to access your account. Create one [here](https://cloud.ibm.com/iam/apikeys).
+* Ruby 2.3.0 or above.
+
+## Installation
+
+To install, use `gem`
+
+```bash
+gem install "ibm_cloud_resource_manager"
+```
+
+## Using the SDK
+For general SDK usage information, please see [this link](https://github.com/IBM/ibm-cloud-sdk-common/blob/master/README.md)
+
+### Authentication
+
+```ruby
+require 'ibm_cloud_resource_manager'
+
+# First select an authentication type (IAM, Bearer, etc...)
+# See https://github.com/IBM/ibm-cloud-sdk-common/blob/master/README.md#authentication for
+# a full list of available authenticators.
+
+# IAM example
+authenticator = IBMCloudSdkCore::IamAuthenticator.new(apikey: "<iam_apikey>")
+
+# Bearer Token example
+authenticator = IBMCloudSdkCore::BearerTokenAuthenticator.new(bearer_token: "<access_token>")
+```
+
+### Using the Resource Manager API client
+
+Setting up and using the API client is simple, just pass in your authenticator object and then you can issue API calls:
+
+```ruby
+
+# Pass the authenticator into the VpcV1 service
+resource_manager = IbmCloudResourceManager::ResourceManagerV2.new(:authenticator => authenticator)
+
+# Now you can start to make API calls
+response = resource_manager.list_resource_groups
+response.response["resources"].each do |resource|
+  puts resource["name"]
+end
+```
+
+## Questions
+
+If you are having difficulties using this SDK or have a question about the IBM Cloud services,
+please ask a question
+[Stack Overflow](http://stackoverflow.com/questions/ask?tags=ibm-cloud).
+
+## Issues
+If you encounter an issue with the project, you are welcome to submit a
+[bug report](https://github.com/IBM/vpc-ruby-sdk/issues).
+Before that, please search for similar issues. It's possible that someone has already reported the problem.
+
+## Open source @ IBM
+Find more open source projects on the [IBM Github Page](http://ibm.github.io/)
+
+## Contributing
+See [CONTRIBUTING.md](https://github.com/IBM/vpc-ruby-sdk/blob/master/CONTRIBUTING.md).
+
+## License
+
+This SDK is released under the Apache 2.0 license.
+The license's full text can be found in [LICENSE](https://github.com/IBM/vpc-ruby-sdk/blob/master/LICENSE).

--- a/gems/ibm_cloud_resource_manager/Rakefile
+++ b/gems/ibm_cloud_resource_manager/Rakefile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/gems/ibm_cloud_resource_manager/bin/console
+++ b/gems/ibm_cloud_resource_manager/bin/console
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'ibm_cloud_resource_manager'
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require 'irb'
+IRB.start(__FILE__)

--- a/gems/ibm_cloud_resource_manager/bin/setup
+++ b/gems/ibm_cloud_resource_manager/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/gems/ibm_cloud_resource_manager/ibm_cloud_resource_manager.gemspec
+++ b/gems/ibm_cloud_resource_manager/ibm_cloud_resource_manager.gemspec
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative 'lib/ibm_cloud_resource_manager/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'ibm_cloud_resource_manager'
+  spec.version       = IbmCloudResourceManager::VERSION
+  spec.authors       = ['adam.grare@ibm.com']
+  spec.email         = ['adam.grare@ibm.com']
+
+  spec.summary       = 'IBM Cloud Resource Manager SDK'
+  spec.homepage      = 'https://github.com/IBM-Cloud/ibm-cloud-sdk-ruby'
+  spec.licenses      = ['Apache-2.0']
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.3.0')
+
+  spec.metadata['allowed_push_host'] = 'https://rubygems.org'
+
+  spec.metadata['homepage_uri'] = spec.homepage
+  spec.metadata['source_code_uri'] = spec.homepage
+  spec.metadata['changelog_uri'] = "#{spec.metadata['source_code_uri']}/blob/main/CHANGELOG.md"
+
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  end
+  spec.bindir        = 'exe'
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ['lib']
+
+  spec.add_runtime_dependency 'ibm_cloud_sdk_core', '~> 1.1.3'
+end

--- a/gems/ibm_cloud_resource_manager/lib/ibm_cloud_resource_manager.rb
+++ b/gems/ibm_cloud_resource_manager/lib/ibm_cloud_resource_manager.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'ibm_cloud_sdk_core'
+
+require_relative 'ibm_cloud_resource_manager/version'
+
+# SDK for accessing IBM Resource Manager API using IBM tooling.
+module IbmCloudResourceManager
+  ApiException = IBMCloudSdkCore::ApiException
+  DetailedResponse = IBMCloudSdkCore::DetailedResponse
+
+  require_relative 'ibm_cloud_resource_manager/common'
+  require_relative 'ibm_cloud_resource_manager/resource_manager_v2'
+end

--- a/gems/ibm_cloud_resource_manager/lib/ibm_cloud_resource_manager/common.rb
+++ b/gems/ibm_cloud_resource_manager/lib/ibm_cloud_resource_manager/common.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative 'version'
+
+module IbmCloudResourceManager
+  # SDK Common class
+  class Common
+    def initialize(*); end
+
+    def get_sdk_headers(service_name, service_version, operation_id)
+      headers = {}
+      user_agent_string = "ibm_cloud_resource_manager-ruby-sdk-#{IbmCloudResourceManager::VERSION} #{RbConfig::CONFIG['host']}"
+      user_agent_string += "#{RbConfig::CONFIG['RUBY_BASE_NAME']}-#{RbConfig::CONFIG['RUBY_PROGRAM_VERSION']}"
+
+      headers['User-Agent'] = user_agent_string
+      return headers if service_name.nil? || service_version.nil? || operation_id.nil?
+
+      headers['X-IBMCloud-SDK-Analytics'] =
+        "service_name=#{service_name};service_version=#{service_version};operation_id=#{operation_id}"
+      headers
+    end
+  end
+end

--- a/gems/ibm_cloud_resource_manager/lib/ibm_cloud_resource_manager/resource_manager_v2.rb
+++ b/gems/ibm_cloud_resource_manager/lib/ibm_cloud_resource_manager/resource_manager_v2.rb
@@ -1,0 +1,260 @@
+# frozen_string_literal: true
+
+# (C) Copyright IBM Corp. 2021.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# IBM OpenAPI SDK Code Generator Version: 3.29.1-b338fb38-20210313-010605
+#
+# Manage lifecycle of your Cloud resource groups using Resource Manager APIs.
+
+require "concurrent"
+require "erb"
+require "json"
+require "ibm_cloud_sdk_core"
+require_relative "./common.rb"
+
+module IbmCloudResourceManager
+  ##
+  # The Resource Manager V2 service.
+  class ResourceManagerV2 < IBMCloudSdkCore::BaseService
+    include Concurrent::Async
+    DEFAULT_SERVICE_NAME = "resource_manager"
+    DEFAULT_SERVICE_URL = "https://resource-controller.cloud.ibm.com/v2"
+    ##
+    # @!method initialize(args)
+    # Construct a new client for the Resource Manager service.
+    #
+    # @param args [Hash] The args to initialize with
+    # @option args service_url [String] The base service URL to use when contacting the service.
+    #   The base service_url may differ between IBM Cloud regions.
+    # @option args authenticator [Object] The Authenticator instance to be configured for this service.
+    # @option args service_name [String] The name of the service to configure. Will be used as the key to load
+    #   any external configuration, if applicable.
+    def initialize(args = {})
+      @__async_initialized__ = false
+      defaults = {}
+      defaults[:service_url] = DEFAULT_SERVICE_URL
+      defaults[:service_name] = DEFAULT_SERVICE_NAME
+      defaults[:authenticator] = nil
+      user_service_url = args[:service_url] unless args[:service_url].nil?
+      args = defaults.merge(args)
+      super
+      @service_url = user_service_url unless user_service_url.nil?
+    end
+
+    #########################
+    # Resource Group
+    #########################
+
+    ##
+    # @!method list_resource_groups(account_id: nil, date: nil, name: nil, default: nil, include_deleted: nil)
+    # Get a list of all resource groups.
+    # Get a list of all resource groups in an account.
+    # @param account_id [String] The ID of the account that contains the resource groups that you want to get.
+    # @param date [String] The date in the format of YYYY-MM which returns resource groups. Deleted resource
+    #   groups will be excluded before this month.
+    # @param name [String] The name of the resource group.
+    # @param default [Boolean] Boolean value to specify whether or not to list default resource groups.
+    # @param include_deleted [Boolean] Boolean value to specify whether or not to list default resource groups.
+    # @return [IBMCloudSdkCore::DetailedResponse] A `IBMCloudSdkCore::DetailedResponse` object representing the response.
+    def list_resource_groups(account_id: nil, date: nil, name: nil, default: nil, include_deleted: nil)
+      headers = {
+      }
+      sdk_headers = Common.new.get_sdk_headers("resource_manager", "V2", "list_resource_groups")
+      headers.merge!(sdk_headers)
+
+      params = {
+        "account_id" => account_id,
+        "date" => date,
+        "name" => name,
+        "default" => default,
+        "include_deleted" => include_deleted
+      }
+
+      method_url = "/resource_groups"
+
+      response = request(
+        method: "GET",
+        url: method_url,
+        headers: headers,
+        params: params,
+        accept_json: true
+      )
+      response
+    end
+
+    ##
+    # @!method create_resource_group(name: nil, account_id: nil)
+    # Create a new resource group.
+    # Create a new resource group in an account.
+    # @param name [String] The new name of the resource group.
+    # @param account_id [String] The account id of the resource group.
+    # @return [IBMCloudSdkCore::DetailedResponse] A `IBMCloudSdkCore::DetailedResponse` object representing the response.
+    def create_resource_group(name: nil, account_id: nil)
+      headers = {
+      }
+      sdk_headers = Common.new.get_sdk_headers("resource_manager", "V2", "create_resource_group")
+      headers.merge!(sdk_headers)
+
+      data = {
+        "name" => name,
+        "account_id" => account_id
+      }
+
+      method_url = "/resource_groups"
+
+      response = request(
+        method: "POST",
+        url: method_url,
+        headers: headers,
+        json: data,
+        accept_json: true
+      )
+      response
+    end
+
+    ##
+    # @!method get_resource_group(id:)
+    # Get a resource group.
+    # Retrieve a resource group by ID.
+    # @param id [String] The short or long ID of the alias.
+    # @return [IBMCloudSdkCore::DetailedResponse] A `IBMCloudSdkCore::DetailedResponse` object representing the response.
+    def get_resource_group(id:)
+      raise ArgumentError.new("id must be provided") if id.nil?
+
+      headers = {
+      }
+      sdk_headers = Common.new.get_sdk_headers("resource_manager", "V2", "get_resource_group")
+      headers.merge!(sdk_headers)
+
+      method_url = "/resource_groups/%s" % [ERB::Util.url_encode(id)]
+
+      response = request(
+        method: "GET",
+        url: method_url,
+        headers: headers,
+        accept_json: true
+      )
+      response
+    end
+
+    ##
+    # @!method update_resource_group(id:, name: nil, state: nil)
+    # Update a resource group.
+    # Update a resource group by ID.
+    # @param id [String] The short or long ID of the alias.
+    # @param name [String] The new name of the resource group.
+    # @param state [String] The state of the resource group.
+    # @return [IBMCloudSdkCore::DetailedResponse] A `IBMCloudSdkCore::DetailedResponse` object representing the response.
+    def update_resource_group(id:, name: nil, state: nil)
+      raise ArgumentError.new("id must be provided") if id.nil?
+
+      headers = {
+      }
+      sdk_headers = Common.new.get_sdk_headers("resource_manager", "V2", "update_resource_group")
+      headers.merge!(sdk_headers)
+
+      data = {
+        "name" => name,
+        "state" => state
+      }
+
+      method_url = "/resource_groups/%s" % [ERB::Util.url_encode(id)]
+
+      response = request(
+        method: "PATCH",
+        url: method_url,
+        headers: headers,
+        json: data,
+        accept_json: true
+      )
+      response
+    end
+
+    ##
+    # @!method delete_resource_group(id:)
+    # Delete a resource group.
+    # Delete a resource group by ID.
+    # @param id [String] The short or long ID of the alias.
+    # @return [nil]
+    def delete_resource_group(id:)
+      raise ArgumentError.new("id must be provided") if id.nil?
+
+      headers = {
+      }
+      sdk_headers = Common.new.get_sdk_headers("resource_manager", "V2", "delete_resource_group")
+      headers.merge!(sdk_headers)
+
+      method_url = "/resource_groups/%s" % [ERB::Util.url_encode(id)]
+
+      request(
+        method: "DELETE",
+        url: method_url,
+        headers: headers,
+        accept_json: false
+      )
+      nil
+    end
+    #########################
+    # Quota Definition
+    #########################
+
+    ##
+    # @!method list_quota_definitions
+    # List quota definitions.
+    # Get a list of all quota definitions.
+    # @return [IBMCloudSdkCore::DetailedResponse] A `IBMCloudSdkCore::DetailedResponse` object representing the response.
+    def list_quota_definitions
+      headers = {
+      }
+      sdk_headers = Common.new.get_sdk_headers("resource_manager", "V2", "list_quota_definitions")
+      headers.merge!(sdk_headers)
+
+      method_url = "/quota_definitions"
+
+      response = request(
+        method: "GET",
+        url: method_url,
+        headers: headers,
+        accept_json: true
+      )
+      response
+    end
+
+    ##
+    # @!method get_quota_definition(id:)
+    # Get a quota definition.
+    # Get a a quota definition.
+    # @param id [String] The id of the quota.
+    # @return [IBMCloudSdkCore::DetailedResponse] A `IBMCloudSdkCore::DetailedResponse` object representing the response.
+    def get_quota_definition(id:)
+      raise ArgumentError.new("id must be provided") if id.nil?
+
+      headers = {
+      }
+      sdk_headers = Common.new.get_sdk_headers("resource_manager", "V2", "get_quota_definition")
+      headers.merge!(sdk_headers)
+
+      method_url = "/quota_definitions/%s" % [ERB::Util.url_encode(id)]
+
+      response = request(
+        method: "GET",
+        url: method_url,
+        headers: headers,
+        accept_json: true
+      )
+      response
+    end
+  end
+end

--- a/gems/ibm_cloud_resource_manager/lib/ibm_cloud_resource_manager/version.rb
+++ b/gems/ibm_cloud_resource_manager/lib/ibm_cloud_resource_manager/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module IbmCloudResourceManager
+  VERSION = '0.1.0'
+end

--- a/gems/ibm_cloud_resource_manager/spec/spec_helper.rb
+++ b/gems/ibm_cloud_resource_manager/spec/spec_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'ibm_cloud_resource_manager'
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = '.rspec_status'
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION
# Description
Adds IBM-derived resource manager sdk https://cloud.ibm.com/apidocs/resource-controller/resource-manager. Used in VPC provision.

# Priority
Required to add provisioning to IBM VPC plugin. Need to wait for VPC SDK to be published by IBM.

# Implementation
Use IBM tools to generate Resource Manager API access from https://cloud.ibm.com/apidocs/resource-controller/resource-manager.json.

# Not covered
* Resource Controller https://cloud.ibm.com/apidocs/resource-controller/resource-controller API is not added .

# Spec
* No specs created.

# Common files
* No common files changed.