### PR TITLE
Update tagging reqs

### DIFF
--- a/gems/ibm_cloud_global_tagging/ibm_cloud_global_tagging.gemspec
+++ b/gems/ibm_cloud_global_tagging/ibm_cloud_global_tagging.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "http", "~> 4.1.0"
   spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.1.1"
   spec.add_runtime_dependency "jwt", "~> 2.2.1"
+  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.1.3"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "codecov"

--- a/gems/ibm_cloud_global_tagging/ibm_cloud_global_tagging.gemspec
+++ b/gems/ibm_cloud_global_tagging/ibm_cloud_global_tagging.gemspec
@@ -26,10 +26,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
-  spec.add_runtime_dependency "http", "~> 4.1.0"
-  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.1.1"
-  spec.add_runtime_dependency "jwt", "~> 2.2.1"
   spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.1.3"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
# Description
The latest SDK core release is Ruby 2.7 compatible.

# Priority
Needed to not have Core SDK req conflicts with new resource manager gem. Need to wait for VPC SDK to be published.

# Implementation
Update requirements to use the latest Core SDK release. Also removed requirements that are covered by core SDK. This should simplify future updates.

# Not covered
* n/a

# Specs
* No specs updated.

# Common files
* No common files changed.