### PR TITLE
Resource manager ns

### DIFF
--- a/gems/ibm_cloud_resource_controller/lib/ibm_cloud_resource_controller/resource_manager_v2.rb
+++ b/gems/ibm_cloud_resource_controller/lib/ibm_cloud_resource_controller/resource_manager_v2.rb
@@ -24,7 +24,7 @@ require "json"
 require "ibm_cloud_sdk_core"
 require_relative "./common.rb"
 
-module IbmCloudResourceManager
+module IbmCloudResourceController
   ##
   # The Resource Manager V2 service.
   class ResourceManagerV2 < IBMCloudSdkCore::BaseService

--- a/gems/ibm_cloud_resource_controller/lib/ibm_cloud_resource_controller/version.rb
+++ b/gems/ibm_cloud_resource_controller/lib/ibm_cloud_resource_controller/version.rb
@@ -1,3 +1,3 @@
 module IbmCloudResourceController
-  VERSION = "2.0.0"
+  VERSION = '2.0.1'
 end


### PR DESCRIPTION
# Issue
The root namespace needs to be the same for the entire gem.

# Priority
* Needed for VPC provision

# Implementation
* Change `IbmCloudResourceManager::ResourceManagerV2` to `IbmCloudResourceController::ResourceManagerV2`
* Update version to 2.0.1

# Not covered
* n/a

# Specs
* No updates
* Manually tested in REPL

# Common files
* No common files changed
