### PR TITLE
Remove enum validations that aren't being honored by the PowerVS API responses

### DIFF
--- a/gems/ibm_cloud_power/lib/ibm_cloud_power/models/create_image.rb
+++ b/gems/ibm_cloud_power/lib/ibm_cloud_power/models/create_image.rb
@@ -186,8 +186,7 @@ module IbmCloudPower
       return false if @source.nil?
       source_validator = EnumAttributeValidator.new('String', ["root-project", "url"])
       return false unless source_validator.valid?(@source)
-      os_type_validator = EnumAttributeValidator.new('String', ["aix", "ibmi", "redhat", "sles"])
-      return false unless os_type_validator.valid?(@os_type)
+      return false if @os_type.nil?
       true
     end
 
@@ -199,16 +198,6 @@ module IbmCloudPower
         fail ArgumentError, "invalid value for \"source\", must be one of #{validator.allowable_values}."
       end
       @source = source
-    end
-
-    # Custom attribute writer method checking allowed values (enum).
-    # @param [Object] os_type Object to be assigned
-    def os_type=(os_type)
-      validator = EnumAttributeValidator.new('String', ["aix", "ibmi", "redhat", "sles"])
-      unless validator.valid?(os_type)
-        fail ArgumentError, "invalid value for \"os_type\", must be one of #{validator.allowable_values}."
-      end
-      @os_type = os_type
     end
 
     # Checks equality by comparing each attribute.
@@ -333,7 +322,7 @@ module IbmCloudPower
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash

--- a/gems/ibm_cloud_power/lib/ibm_cloud_power/models/sap_profile.rb
+++ b/gems/ibm_cloud_power/lib/ibm_cloud_power/models/sap_profile.rb
@@ -149,22 +149,10 @@ module IbmCloudPower
     def valid?
       return false if @profile_id.nil?
       return false if @type.nil?
-      type_validator = EnumAttributeValidator.new('String', ["balanced", "compute", "memory", "non-production", "ultra-memory"])
-      return false unless type_validator.valid?(@type)
       return false if @cores.nil?
       return false if @memory.nil?
       return false if @certified.nil?
       true
-    end
-
-    # Custom attribute writer method checking allowed values (enum).
-    # @param [Object] type Object to be assigned
-    def type=(type)
-      validator = EnumAttributeValidator.new('String', ["balanced", "compute", "memory", "non-production", "ultra-memory"])
-      unless validator.valid?(type)
-        fail ArgumentError, "invalid value for \"type\", must be one of #{validator.allowable_values}."
-      end
-      @type = type
     end
 
     # Checks equality by comparing each attribute.
@@ -283,7 +271,7 @@ module IbmCloudPower
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash


### PR DESCRIPTION
The PCloudSAP API is returning SAPProfile objects with "type": "small".
Temporarily patching the validator until the PowerVS team fixes the
OpenAPI definition.