### PR TITLE
Bump activity tracker gem to 0.1.1

### DIFF
--- a/gems/ibm_cloud_activity_tracker/lib/ibm_cloud_activity_tracker/version.rb
+++ b/gems/ibm_cloud_activity_tracker/lib/ibm_cloud_activity_tracker/version.rb
@@ -1,3 +1,3 @@
 module IbmCloudActivityTracker
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
@agrare For re-releasing the `ibm_cloud_activity_tracker` gem