### PR TITLE
Set minimum values for dependencies to avoid CVEs

### DIFF
--- a/ibm-cloud-sdk.gemspec
+++ b/ibm-cloud-sdk.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rest-client"
-  spec.add_dependency "httparty"
+  spec.add_dependency "rest-client", ">= 1.8.0"
+  spec.add_dependency "httparty",    ">= 0.21.0"
 end


### PR DESCRIPTION
@agrare Please review.

Recently, https://github.com/jnunemaker/httparty/security/advisories/GHSA-5pq7-52mg-hr42 was released that found a security issue in httparty 0.20.  This PR sets the minimum to 0.21.

While I was in there I also set the minimum for rest-client to a known-good version.