### PR TITLE
Fix some known HTTP::ConnectionError issues resolved in 5.0.1 and 5.1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in ibm-cloud-sdk.gemspec
 gemspec
 
-gem "rake", "~> 12.0"
+gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem 'vcr'
 gem 'webmock'

--- a/gems/ibm_cloud/Gemfile
+++ b/gems/ibm_cloud/Gemfile
@@ -3,5 +3,5 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in ibm_cloud.gemspec
 gemspec
 
-gem "rake", "~> 12.0"
+gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"

--- a/gems/ibm_cloud_activity_tracker/Gemfile
+++ b/gems/ibm_cloud_activity_tracker/Gemfile
@@ -3,5 +3,5 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in ibm_cloud_activity_tracker.gemspec
 gemspec
 
-gem "rake", "~> 12.0"
+gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"

--- a/gems/ibm_cloud_activity_tracker/ibm_cloud_activity_tracker.gemspec
+++ b/gems/ibm_cloud_activity_tracker/ibm_cloud_activity_tracker.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
   spec.add_runtime_dependency "http", "~> 5.1.1"
-  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.1.1"
+  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.2.0"
   spec.add_runtime_dependency "jwt", "~> 2.2.1"
 
   spec.add_development_dependency "bundler", "~> 2.1"

--- a/gems/ibm_cloud_activity_tracker/ibm_cloud_activity_tracker.gemspec
+++ b/gems/ibm_cloud_activity_tracker/ibm_cloud_activity_tracker.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
-  spec.add_runtime_dependency "http", "~> 4.4.1"
+  spec.add_runtime_dependency "http", "~> 5.1.1"
   spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.1.1"
   spec.add_runtime_dependency "jwt", "~> 2.2.1"
 

--- a/gems/ibm_cloud_databases/Gemfile
+++ b/gems/ibm_cloud_databases/Gemfile
@@ -3,5 +3,5 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in ibm_cloud_databases.gemspec
 gemspec
 
-gem "rake", "~> 12.0"
+gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"

--- a/gems/ibm_cloud_databases/ibm_cloud_databases.gemspec
+++ b/gems/ibm_cloud_databases/ibm_cloud_databases.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
-  spec.add_runtime_dependency "http", "~> 4.4.1"
+  spec.add_runtime_dependency "http", "~> 5.1.1"
   spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.1.1"
   spec.add_runtime_dependency "jwt", "~> 2.2.1"
 end

--- a/gems/ibm_cloud_databases/ibm_cloud_databases.gemspec
+++ b/gems/ibm_cloud_databases/ibm_cloud_databases.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
   spec.add_runtime_dependency "http", "~> 5.1.1"
-  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.1.1"
+  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.2.0"
   spec.add_runtime_dependency "jwt", "~> 2.2.1"
 end

--- a/gems/ibm_cloud_global_tagging/Gemfile
+++ b/gems/ibm_cloud_global_tagging/Gemfile
@@ -3,5 +3,5 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in ibm_cloud_global_tagging.gemspec
 gemspec
 
-gem "rake", "~> 12.0"
+gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"

--- a/gems/ibm_cloud_global_tagging/ibm_cloud_global_tagging.gemspec
+++ b/gems/ibm_cloud_global_tagging/ibm_cloud_global_tagging.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.1.3"
+  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.2.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "codecov"

--- a/gems/ibm_cloud_resource_controller/Gemfile
+++ b/gems/ibm_cloud_resource_controller/Gemfile
@@ -3,5 +3,5 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in ibm_cloud_resource_controller.gemspec
 gemspec
 
-gem "rake", "~> 12.0"
+gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"

--- a/gems/ibm_cloud_resource_controller/ibm_cloud_resource_controller.gemspec
+++ b/gems/ibm_cloud_resource_controller/ibm_cloud_resource_controller.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.1.1"
+  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.2.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Note, there are some breaking changes in version 5.0.0:
https://github.com/httprb/http/blob/main/CHANGES.md#500-2021-05-12

~~NOTE 2, this PR will depend on https://github.com/IBM/ruby-sdk-core/pull/40 being merged, released, and bumping the `ibm_cloud_sdk_core` dependency in the various gemspecs in this repository.~~

Similar change as https://github.com/IBM/vpc-ruby-sdk/pull/24