### PR TITLE
Bump ibm_cloud_sdk_core to 1.3.0

### DIFF
--- a/gems/ibm_cloud_activity_tracker/ibm_cloud_activity_tracker.gemspec
+++ b/gems/ibm_cloud_activity_tracker/ibm_cloud_activity_tracker.gemspec
@@ -26,10 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
-  spec.add_runtime_dependency "http", "~> 5.1.1"
-  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.2.0"
-  spec.add_runtime_dependency "jwt", "~> 2.2.1"
+  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.3.0"
 
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "codecov", "~> 0.1"

--- a/gems/ibm_cloud_databases/ibm_cloud_databases.gemspec
+++ b/gems/ibm_cloud_databases/ibm_cloud_databases.gemspec
@@ -26,8 +26,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
-  spec.add_runtime_dependency "http", "~> 5.1.1"
-  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.2.0"
-  spec.add_runtime_dependency "jwt", "~> 2.2.1"
+  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.3.0"
 end

--- a/gems/ibm_cloud_global_tagging/ibm_cloud_global_tagging.gemspec
+++ b/gems/ibm_cloud_global_tagging/ibm_cloud_global_tagging.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.2.0"
+  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.3.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "codecov"

--- a/gems/ibm_cloud_resource_controller/ibm_cloud_resource_controller.gemspec
+++ b/gems/ibm_cloud_resource_controller/ibm_cloud_resource_controller.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.2.0"
+  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.3.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Also remove a number of redundant dependencies which were copied from ibm_cloud_sdk_core

Ref: https://github.com/IBM/ruby-sdk-core/pull/43