### PR TITLE
Fix missing uri require in rake openapi:generate

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require "uri"
 
 RSpec::Core::RakeTask.new(:spec)
 


### PR DESCRIPTION
Fixes:
```
rake aborted!
NoMethodError: undefined method `URI' for main (NoMethodError)

      uri          = URI("https://cloud.ibm.com/apidocs/#{openapi_json}")

```