### PR TITLE
Update openapi generator version

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ namespace :openapi do
   }
 
   task :download_cli, [:version] do |_t, args|
-    version = args[:version] || "5.0.0-beta2"
+    version = args[:version] || "5.4.0"
 
     output_file    = "openapi-generator-cli-#{version}.jar"
     target_symlink = "openapi-generator-cli"

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require "uri"
 
 RSpec::Core::RakeTask.new(:spec)
 


### PR DESCRIPTION
Depends on:
- [x] https://github.com/IBM-Cloud/ibm-cloud-sdk-ruby/pull/76