### PR TITLE
Allow nil proc_type for VMs

### DIFF
--- a/gems/ibm_cloud_power/lib/ibm_cloud_power/models/pvm_instance_reference.rb
+++ b/gems/ibm_cloud_power/lib/ibm_cloud_power/models/pvm_instance_reference.rb
@@ -519,9 +519,10 @@ module IbmCloudPower
       return false if @image_id.nil?
       return false if @memory.nil?
       return false if @os_type.nil?
-      return false if @proc_type.nil?
-      proc_type_validator = EnumAttributeValidator.new('String', ["dedicated", "shared", "capped"])
-      return false unless proc_type_validator.valid?(@proc_type)
+      unless @proc_type.nil?
+        proc_type_validator = EnumAttributeValidator.new('String', ["dedicated", "shared", "capped"])
+        return false unless proc_type_validator.valid?(@proc_type)
+      end
       return false if @processors.nil?
       return false if @pvm_instance_id.nil?
       return false if @server_name.nil?
@@ -532,6 +533,10 @@ module IbmCloudPower
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] proc_type Object to be assigned
     def proc_type=(proc_type)
+      if proc_type.nil? || proc_type.to_s.strip.empty?
+        @proc_type = nil
+        return
+      end
       validator = EnumAttributeValidator.new('String', ["dedicated", "shared", "capped"])
       unless validator.valid?(proc_type)
         fail ArgumentError, "invalid value for \"proc_type\", must be one of #{validator.allowable_values}."


### PR DESCRIPTION
When VMs are in a bad state, the proc_type value will be nil. Previously, this caused the refresher to fail with: 
'invalid value for \"proc_type\", must be one of [\"dedicated\", \"shared\", \"capped\"]'

This change allows nil values for proc_type to prevent refresh failures when processing VMs in bad state.