### PR TITLE
Fix openapi gem generation

### DIFF
--- a/.github/workflows/openapi-generate.yml
+++ b/.github/workflows/openapi-generate.yml
@@ -33,7 +33,7 @@ jobs:
       run: sudo apt install -y xq
     - name: Download OpenAPI Spec
       run: |
-        curl ${{ matrix.spec_url }} -o "${{ matrix.spec_file }}"
+        curl --location ${{ matrix.spec_url }} --output "${{ matrix.spec_file }}"
     - name: OpenAPI Generate
       env:
         GEM_NAME: ${{ matrix.gem_name }}

--- a/gems/ibm_cloud_global_tagging/.openapi-config.json
+++ b/gems/ibm_cloud_global_tagging/.openapi-config.json
@@ -3,5 +3,6 @@
   "gemAuthor": "IBM Cloud Developers",
   "gemSummary": "IBM Cloud Global Tagging",
   "gemDescription": "Ruby gem for IBM Cloud Global Tagging",
-  "gemLicense": "Apache-2.0"
+  "gemLicense": "Apache-2.0",
+  "gemVersion": "0.1.3"
 }

--- a/gems/ibm_cloud_global_tagging/.openapi-config.json
+++ b/gems/ibm_cloud_global_tagging/.openapi-config.json
@@ -1,0 +1,7 @@
+{
+  "gemName": "ibm_cloud_global_tagging",
+  "gemAuthor": "IBM Cloud Developers",
+  "gemSummary": "IBM Cloud Global Tagging",
+  "gemDescription": "Ruby gem for IBM Cloud Global Tagging",
+  "gemLicense": "Apache-2.0"
+}

--- a/gems/ibm_cloud_iam/.openapi-config.json
+++ b/gems/ibm_cloud_iam/.openapi-config.json
@@ -3,5 +3,6 @@
   "gemAuthor": "IBM Cloud Developers",
   "gemSummary": "IBM Cloud IAM Identity Services",
   "gemDescription": "Ruby gem for IBM Cloud IAM Identity Services",
-  "gemLicense": "Apache-2.0"
+  "gemLicense": "Apache-2.0",
+  "gemVersion": "1.0.1"
 }

--- a/gems/ibm_cloud_resource_controller/.openapi-config.json
+++ b/gems/ibm_cloud_resource_controller/.openapi-config.json
@@ -1,0 +1,7 @@
+{
+  "gemName": "ibm_cloud_resource_controller",
+  "gemAuthor": "IBM Cloud Developers",
+  "gemSummary": "IBM Cloud Resource Controller",
+  "gemDescription": "Ruby gem for IBM Cloud Resource Controller",
+  "gemLicense": "Apache-2.0"
+}

--- a/gems/ibm_cloud_resource_controller/.openapi-config.json
+++ b/gems/ibm_cloud_resource_controller/.openapi-config.json
@@ -3,5 +3,6 @@
   "gemAuthor": "IBM Cloud Developers",
   "gemSummary": "IBM Cloud Resource Controller",
   "gemDescription": "Ruby gem for IBM Cloud Resource Controller",
-  "gemLicense": "Apache-2.0"
+  "gemLicense": "Apache-2.0",
+  "gemVersion": "2.0.3"
 }


### PR DESCRIPTION
Fix a number of issues:
1. Downloading the spec files with `curl` wasn't following redirects causing `0` byte spec files [[ref]](https://github.com/IBM-Cloud/ibm-cloud-sdk-ruby/actions/runs/28621717097/job/84878773857#step:5:642)
2. Two gems were missing `.openapi-config.json` files [[ref]](https://github.com/IBM-Cloud/ibm-cloud-sdk-ruby/actions/runs/28621717097/job/84878773850#step:5:644)
3. `gemVersion` was missing from `.openapi-config.json` which would have overwritten the `lib/GEM/version.rb` file.