### PR TITLE
Fix invalid regular expressions in `TargetTrustedProfile` and `VPMemVolumeUpdate` classes

### DIFF
--- a/patches/patch_power-cloud.sh
+++ b/patches/patch_power-cloud.sh
@@ -43,8 +43,14 @@ yq '.components.schemas.UpdateWorkspaceSSHKey.properties.name.pattern = "^[a-zA-
 yq '.components.schemas.WorkspaceSSHKey.properties.name.pattern = "^[a-zA-Z0-9\\-_][a-zA-Z0-9\\-_]*$"' \
   "${SPEC_FILE}" > "${SPEC_FILE}.tmp" && mv "${SPEC_FILE}.tmp" "${SPEC_FILE}"
 
+# Fix regex pattern in TargetTrustedProfile schemas to properly escape hyphen
+yq '.components.schemas.TargetTrustedProfile.properties.crn.pattern = "^(crn:v[0-9]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]*:([a-z]\\/[a-z0-9-]+)?:[a-z0-9-]*:[a-z0-9-]*:[a-zA-Z0-9\\-_\\.\\/]*)?$"' \
+  "${SPEC_FILE}" > "${SPEC_FILE}.tmp" && mv "${SPEC_FILE}.tmp" "${SPEC_FILE}"
+
 # Fix regex pattern in VPMemVolumeCreate schema to properly escape hyphen
 yq '.components.schemas.VPMemVolumeCreate.properties.name.pattern = "^[a-zA-Z0-9\\-_][a-zA-Z0-9\\-_]*$"' \
+  "${SPEC_FILE}" > "${SPEC_FILE}.tmp" && mv "${SPEC_FILE}.tmp" "${SPEC_FILE}"
+yq '.components.schemas.VPMemVolumeUpdate.properties.name.pattern = "^[a-zA-Z0-9][a-zA-Z0-9\\-_]*$"' \
   "${SPEC_FILE}" > "${SPEC_FILE}.tmp" && mv "${SPEC_FILE}.tmp" "${SPEC_FILE}"
 
 echo "Pre-generation patches applied successfully to ${SPEC_NAME}"


### PR DESCRIPTION
`TargetTrustedProfile` and `VPMemVolumeUpdate` had invalid regular expressions causing warnings when requiring the gem.

```
adam@workstation:~/src/manageiq/manageiq-providers-ibm_cloud$ bundle exec rspec
/home/grare/adam/src/manageiq/ibm-cloud-sdk-ruby/gems/ibm_cloud_power/lib/ibm_cloud_power/models/target_trusted_profile.rb:100: warning: character class has '-' without escape
/home/grare/adam/src/manageiq/ibm-cloud-sdk-ruby/gems/ibm_cloud_power/lib/ibm_cloud_power/models/target_trusted_profile.rb:122: warning: character class has '-' without escape
/home/grare/adam/src/manageiq/ibm-cloud-sdk-ruby/gems/ibm_cloud_power/lib/ibm_cloud_power/models/target_trusted_profile.rb:139: warning: character class has '-' without escape
/home/grare/adam/src/manageiq/ibm-cloud-sdk-ruby/gems/ibm_cloud_power/lib/ibm_cloud_power/models/target_trusted_profile.rb: warning: character class has '-' without escape
/home/grare/adam/src/manageiq/ibm-cloud-sdk-ruby/gems/ibm_cloud_power/lib/ibm_cloud_power/models/target_trusted_profile.rb: warning: character class has '-' without escape
/home/grare/adam/src/manageiq/ibm-cloud-sdk-ruby/gems/ibm_cloud_power/lib/ibm_cloud_power/models/target_trusted_profile.rb: warning: character class has '-' without escape
/home/grare/adam/src/manageiq/ibm-cloud-sdk-ruby/gems/ibm_cloud_power/lib/ibm_cloud_power/models/vp_mem_volume_update.rb:91: warning: character class has '-' without escape: /^[a-zA-Z0-9][a-zA-Z0-9-_]*$/
/home/grare/adam/src/manageiq/ibm-cloud-sdk-ruby/gems/ibm_cloud_power/lib/ibm_cloud_power/models/vp_mem_volume_update.rb:106: warning: character class has '-' without escape: /^[a-zA-Z0-9][a-zA-Z0-9-_]*$/
/home/grare/adam/src/manageiq/ibm-cloud-sdk-ruby/gems/ibm_cloud_power/lib/ibm_cloud_power/models/vp_mem_volume_update.rb:125: warning: character class has '-' without escape: /^[a-zA-Z0-9][a-zA-Z0-9-_]*$/
/home/grare/adam/src/manageiq/ibm-cloud-sdk-ruby/gems/ibm_cloud_power/lib/ibm_cloud_power/models/vp_mem_volume_update.rb: warning: character class has '-' without escape: /^[a-zA-Z0-9][a-zA-Z0-9-_]*$/
/home/grare/adam/src/manageiq/ibm-cloud-sdk-ruby/gems/ibm_cloud_power/lib/ibm_cloud_power/models/vp_mem_volume_update.rb: warning: character class has '-' without escape: /^[a-zA-Z0-9][a-zA-Z0-9-_]*$/
/home/grare/adam/src/manageiq/ibm-cloud-sdk-ruby/gems/ibm_cloud_power/lib/ibm_cloud_power/models/vp_mem_volume_update.rb: warning: character class has '-' without escape: /^[a-zA-Z0-9][a-zA-Z0-9-_]*$/
```

After updating the `patches/` file and re-running the openapi generator I see the following diff when built on top of https://github.com/IBM-Cloud/ibm-cloud-sdk-ruby/pull/87

```diff
adam@workstation:~/src/manageiq/ibm-cloud-sdk-ruby$ git diff
diff --git a/gems/ibm_cloud_power/lib/ibm_cloud_power/models/target_trusted_profile.rb b/gems/ibm_cloud_power/lib/ibm_cloud_power/models/target_trusted_profile.rb
index fd1fa9f..9d7e858 100644
--- a/gems/ibm_cloud_power/lib/ibm_cloud_power/models/target_trusted_profile.rb
+++ b/gems/ibm_cloud_power/lib/ibm_cloud_power/models/target_trusted_profile.rb
@@ -97,7 +97,7 @@ module IbmCloudPower
         invalid_properties.push('invalid value for "crn", the character length must be smaller than or equal to 512.')
       end
 
-      pattern = Regexp.new(/^(crn:v[0-9]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]*:([a-z]\/[a-z0-9-]+)?:[a-z0-9-]*:[a-z0-9-]*:[a-zA-Z0-9-_\.\/]*)?$/)
+      pattern = Regexp.new(/^(crn:v[0-9]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]*:([a-z]\/[a-z0-9-]+)?:[a-z0-9-]*:[a-z0-9-]*:[a-zA-Z0-9\-_\.\/]*)?$/)
       if !@crn.nil? && @crn !~ pattern
         invalid_properties.push("invalid value for \"crn\", must conform to the pattern #{pattern}.")
       end
@@ -119,7 +119,7 @@ module IbmCloudPower
     def valid?
       warn '[DEPRECATED] the `valid?` method is obsolete'
       return false if !@crn.nil? && @crn.to_s.length > 512
-      return false if !@crn.nil? && @crn !~ Regexp.new(/^(crn:v[0-9]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]*:([a-z]\/[a-z0-9-]+)?:[a-z0-9-]*:[a-z0-9-]*:[a-zA-Z0-9-_\.\/]*)?$/)
+      return false if !@crn.nil? && @crn !~ Regexp.new(/^(crn:v[0-9]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]*:([a-z]\/[a-z0-9-]+)?:[a-z0-9-]*:[a-z0-9-]*:[a-zA-Z0-9\-_\.\/]*)?$/)
       return false if !@id.nil? && @id.to_s.length > 64
       return false if !@id.nil? && @id !~ Regexp.new(/^(Profile-[-0-9a-z_]+)?$/)
       true
@@ -136,7 +136,7 @@ module IbmCloudPower
         fail ArgumentError, 'invalid value for "crn", the character length must be smaller than or equal to 512.'
       end
 
-      pattern = Regexp.new(/^(crn:v[0-9]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]*:([a-z]\/[a-z0-9-]+)?:[a-z0-9-]*:[a-z0-9-]*:[a-zA-Z0-9-_\.\/]*)?$/)
+      pattern = Regexp.new(/^(crn:v[0-9]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]*:([a-z]\/[a-z0-9-]+)?:[a-z0-9-]*:[a-z0-9-]*:[a-zA-Z0-9\-_\.\/]*)?$/)
       if crn !~ pattern
         fail ArgumentError, "invalid value for \"crn\", must conform to the pattern #{pattern}."
       end
diff --git a/gems/ibm_cloud_power/lib/ibm_cloud_power/models/vp_mem_volume_update.rb b/gems/ibm_cloud_power/lib/ibm_cloud_power/models/vp_mem_volume_update.rb
index 73e12cd..da43a8e 100644
--- a/gems/ibm_cloud_power/lib/ibm_cloud_power/models/vp_mem_volume_update.rb
+++ b/gems/ibm_cloud_power/lib/ibm_cloud_power/models/vp_mem_volume_update.rb
@@ -88,7 +88,7 @@ module IbmCloudPower
         invalid_properties.push('invalid value for "name", the character length must be greater than or equal to 1.')
       end
 
-      pattern = Regexp.new(/^[a-zA-Z0-9][a-zA-Z0-9-_]*$/)
+      pattern = Regexp.new(/^[a-zA-Z0-9][a-zA-Z0-9\-_]*$/)
       if @name !~ pattern
         invalid_properties.push("invalid value for \"name\", must conform to the pattern #{pattern}.")
       end
@@ -103,7 +103,7 @@ module IbmCloudPower
       return false if @name.nil?
       return false if @name.to_s.length > 20
       return false if @name.to_s.length < 1
-      return false if @name !~ Regexp.new(/^[a-zA-Z0-9][a-zA-Z0-9-_]*$/)
+      return false if @name !~ Regexp.new(/^[a-zA-Z0-9][a-zA-Z0-9\-_]*$/)
       true
     end
 
@@ -122,7 +122,7 @@ module IbmCloudPower
         fail ArgumentError, 'invalid value for "name", the character length must be greater than or equal to 1.'
       end
 
-      pattern = Regexp.new(/^[a-zA-Z0-9][a-zA-Z0-9-_]*$/)
+      pattern = Regexp.new(/^[a-zA-Z0-9][a-zA-Z0-9\-_]*$/)
       if name !~ pattern
         fail ArgumentError, "invalid value for \"name\", must conform to the pattern #{pattern}."
       end
```