### PR TITLE
Drop label from create-pull-request action

### DIFF
--- a/.github/workflows/openapi-generate.yml
+++ b/.github/workflows/openapi-generate.yml
@@ -49,7 +49,6 @@ jobs:
         author: IBM Jeeves <ibm-jeeves@ibm.com>
         committer: IBM Jeeves <ibm-jeeves@ibm.com>
         delete-branch: true
-        labels: enhancement
         assignees: agrare
         push-to-fork: ibm-jeeves/ibm-cloud-sdk-ruby
         title: Update ${{ matrix.gem_name }} gem from OpenAPI spec


### PR DESCRIPTION
Adding a label to a pull request requires a user with repository admin privileges and isn't necessary.

Fixes:
```
Created pull request #85 (ibm-jeeves:openapi_generate_ibm_cloud_global_tagging => master)
  Applying labels 'enhancement'
  Error: Must have admin rights to Repository. - https://docs.github.com/rest/issues/labels#add-labels-to-an-issue
```