### PR TITLE
Drop assignee from create-pull-request

### DIFF
--- a/.github/workflows/openapi-generate.yml
+++ b/.github/workflows/openapi-generate.yml
@@ -49,7 +49,6 @@ jobs:
         author: IBM Jeeves <ibm-jeeves@ibm.com>
         committer: IBM Jeeves <ibm-jeeves@ibm.com>
         delete-branch: true
-        assignees: agrare
         push-to-fork: ibm-jeeves/ibm-cloud-sdk-ruby
         title: Update ${{ matrix.gem_name }} gem from OpenAPI spec
         body: |


### PR DESCRIPTION
Fixes https://github.com/IBM-Cloud/ibm-cloud-sdk-ruby/actions/runs/28955769974/job/85914180703#step:6:675

```
Create or update the pull request
  Attempting creation of pull request
  A pull request already exists for ibm-jeeves:openapi_generate_ibm_cloud_global_tagging
  Fetching existing pull request
  Attempting update of pull request
  Updated pull request #85 (ibm-jeeves:openapi_generate_ibm_cloud_global_tagging => master)
  Applying assignees 'agrare'
  Error: Must have admin rights to Repository. - https://docs.github.com/rest/issues/assignees#add-assignees-to-an-issue
```